### PR TITLE
Allow for Metal rendering as an option instead of hard-coding to GLSL.

### DIFF
--- a/pymaterialx/mtlxutils/mxrenderer.py
+++ b/pymaterialx/mtlxutils/mxrenderer.py
@@ -3,6 +3,12 @@ import MaterialX.PyMaterialXGenShader as mx_gen_shader
 import MaterialX.PyMaterialXGenGlsl as mx_gen_glsl
 import MaterialX.PyMaterialXRender as mx_render
 import MaterialX.PyMaterialXRenderGlsl as mx_render_glsl
+# Check if PyMaterialXRenderMsl is in Materialx
+try:
+    import MaterialX.PyMaterialXRenderMsl as mx_render_msl
+    haveMslRenderer = True
+except ImportError:
+    haveMslRenderer = False
 from mtlxutils import mxshadergen
 import inspect, os, sys, math
 
@@ -109,6 +115,9 @@ class GlslRenderer():
         # Rendering log
         self.renderLog = []
 
+    def getTarget(self):
+        return 'genglsl'
+
     def getRenderer(self):
         return self.renderer
     
@@ -148,12 +157,15 @@ class GlslRenderer():
     def clearRenderLog(self):
         self.renderLog = []        
 
+    def createRenderer(self, bufferFormat):
+       return mx_render_glsl.GlslRenderer.create(self.renderSize[0], self.renderSize[1], bufferFormat) 
+
     def initialize(self, bufferFormat=mx_render.BaseType.UINT8):
         '''
         Setup sample renderer with a given frame buffer size.
         Initialize image and geometry handlers.
         '''
-        self.renderer = mx_render_glsl.GlslRenderer.create(self.renderSize[0], self.renderSize[1], bufferFormat)
+        self.renderer = self.createRenderer(bufferFormat)
         if self.renderer:
             self.renderer.initialize()
             self.initializeGeometryHandler()
@@ -232,6 +244,9 @@ class GlslRenderer():
         return True            
         
 
+    def createImageHandler(self, imageLoader):
+        return mx_render_glsl.GLTextureHandler.create(imageLoader)
+
     def initializeImageHandler(self, searchPath):   
         '''
         Initialize image handler. 
@@ -242,7 +257,7 @@ class GlslRenderer():
         # TODO: Missing fom the Python API for createImageHandler() 
         #imageHandler = renderer.createImageHandler()
         imageLoader = mx_render.StbImageLoader.create()
-        imageHandler = mx_render_glsl.GLTextureHandler.create(imageLoader)
+        imageHandler = self.createImageHandler(imageLoader)
         # Add OIIO handler if it exists
         if self.haveOIIOImageHandler:
             imageHandler.addLoader(mx_render.OIIOHandler.create())
@@ -343,7 +358,7 @@ class GlslRenderer():
 
         # Check generator and generator options
         mxgenerator = None
-        mxcontext = self.mxgen.setGeneratorForTarget('genglsl')
+        mxcontext = self.mxgen.setGeneratorForTarget(self.getTarget())
         if mxcontext:
             mxgenerator = mxcontext.getShaderGenerator()
 
@@ -359,7 +374,7 @@ class GlslRenderer():
 
     def generateShader(self, node, targetColorSpaceOverride='lin_rec709', targetDistanceUnit='meter'):
         '''
-        Generate new GLSL shader.
+        Generate new shader.
         - Inspects node to check if it requires lighting and / or is transparent.
         - Sets target colorspace and real-world units
         - Generates code and caches it
@@ -409,7 +424,7 @@ class GlslRenderer():
 
     def createProgram(self):
         '''
-        Create a GLSL program from the active shader node and validates it's inputs.
+        Create a HW program from the active shader node and validates it's inputs.
         Note: A light handler **must** be set to for validation to work properly.
         '''
         if not self.activeShader:
@@ -448,6 +463,23 @@ class GlslRenderer():
             return False, err
         
         return True, ''
+
+class MslRenderer(GlslRenderer):
+    '''
+    Wrapper for MSL sample renderer.
+    '''
+    def __init__(self, desiredRenderSize):
+        super().__init__(desiredRenderSize)
+
+    def getTarget(self):
+        return 'genmsl'
+
+    def createRenderer(self, bufferFormat):
+        return mx_render_msl.MslRenderer.create(self.renderSize[0], self.renderSize[1], bufferFormat) 
+
+    def createImageHandler(self, imageLoader):
+        return self.renderer.createImageHandler(imageLoader)
+        #return mx_render_msl.MetalTextureHandler.create(imageLoader)
 
 def getPortPath(inputPath, doc):
     '''
@@ -510,58 +542,70 @@ def debugStages(shader, doc, filter='Public'):
                             print('   - Unit:%s, ColorSpace:%s' % (unit,colorspace))
 
 def initializeRenderer(stdlib, searchPath, 
-                       radianceMapFileName, irrandianceMapFileName, w, h, desiredGeometry):
-    glslRenderer = GlslRenderer([w,h])
-    glslRenderer.initialize(mx_render.BaseType.UINT8)
-    glslRenderer.addToRenderLog('- Initialized renderer')
-    glslRenderer.addToRenderLog('------------------------')
-    glslRenderer.addToRenderLog(' - Have OIIO loader support: %s' % glslRenderer.haveOIIOLoader()) 
-    glslRenderer.addToRenderLog(' - Have GLTF loader support: %s' % glslRenderer.haveGLTFLoader()) 
+                       radianceMapFileName, irrandianceMapFileName, w, h, desiredGeometry,
+                       target = 'genglsl'):
+    
+    renderer = None
+    if target == 'genglsl':
+        renderer = GlslRenderer([w,h])
+        renderer.initialize(mx_render.BaseType.UINT8)
+        renderer.addToRenderLog('- Initialized GLSL renderer')
+    elif target == 'genmsl' and haveMslRenderer:
+        renderer = MslRenderer([w,h])
+        renderer.initialize(mx_render.BaseType.UINT8)
+        renderer.addToRenderLog('- Initialized MSL renderer')
+    else:
+        print('Unsupported target: %s' % target)
+        return None
+
+    renderer.addToRenderLog('------------------------')
+    renderer.addToRenderLog(' - Have OIIO loader support: %s' % renderer.haveOIIOLoader()) 
+    renderer.addToRenderLog(' - Have GLTF loader support: %s' % renderer.haveGLTFLoader()) 
 
     # TODO: This is not exposed in the Pyhon API
     #clearColor = mx.Color3(1.0, 1.0, 1.0)
-    #glslRenderer.setScreenColor(clearColor)
+    #renderer.setScreenColor(clearColor)
 
-    geometryHandler = glslRenderer.getGeometyHandler()
+    geometryHandler = renderer.getGeometyHandler()
     if geometryHandler:
-        glslRenderer.addToRenderLog('- Initialized geometry loader: ' + desiredGeometry)
-        glslRenderer.loadGeometry(desiredGeometry)
+        renderer.addToRenderLog('- Initialized geometry loader: ' + desiredGeometry)
+        renderer.loadGeometry(desiredGeometry)
         for mesh in geometryHandler.getMeshes():
-            glslRenderer.addToRenderLog(' - Loaded Mesh: "%s"' % mesh.getName())
+            renderer.addToRenderLog(' - Loaded Mesh: "%s"' % mesh.getName())
 
     # Update the camera parameters
-    glslRenderer.updateCamera()
+    renderer.updateCamera()
 
     # Set up image handler. Make sure to pass in a suitable search path for images
-    glslRenderer.initializeImageHandler(searchPath)
-    glslRenderer.addToRenderLog(' - Initialize image handler. Search path %s' % glslRenderer.getImageHandler().getSearchPath().asString())
+    renderer.initializeImageHandler(searchPath)
+    renderer.addToRenderLog(' - Initialize image handler. Search path %s' % renderer.getImageHandler().getSearchPath().asString())
 
     # Set up lighting
     enableReferenceQuality = False
     enableDirectLighting = False
     lightDocument = None
-    glslRenderer.initializeLights(lightDocument, enableDirectLighting, 
+    renderer.initializeLights(lightDocument, enableDirectLighting, 
                                   radianceMapFileName, irrandianceMapFileName, enableReferenceQuality)    
-    lightHandler = glslRenderer.getLightHandler()
+    lightHandler = renderer.getLightHandler()
     if lightHandler:
-        glslRenderer.addToRenderLog('- Setup lighting:')
+        renderer.addToRenderLog('- Setup lighting:')
         radMap = lightHandler.getEnvRadianceMap()
         irradMap = lightHandler.getEnvIrradianceMap()
-        glslRenderer.addToRenderLog(' - Loaded radiance map: %d x %d' % (radMap.getWidth(), radMap.getHeight()))
-        glslRenderer.addToRenderLog(' - Loaded irradiance map: %d x %d' % (irradMap.getWidth(), irradMap.getHeight()))
+        renderer.addToRenderLog(' - Loaded radiance map: %d x %d' % (radMap.getWidth(), radMap.getHeight()))
+        renderer.addToRenderLog(' - Loaded irradiance map: %d x %d' % (irradMap.getWidth(), irradMap.getHeight()))
 
     # Set up source code generator. Make sure to set the source code path
     sourceCodeSearchPath = searchPath
-    glslRenderer.setupGenerator(stdlib, sourceCodeSearchPath)
-    context = glslRenderer.getCodeGenerator().getContext()
+    renderer.setupGenerator(stdlib, sourceCodeSearchPath)
+    context = renderer.getCodeGenerator().getContext()
     if context:
         generator = context.getShaderGenerator()
         if generator:
-            glslRenderer.addToRenderLog('- Iniitialize generator for target: %s.\n - Source path: %s' % 
+            renderer.addToRenderLog('- Iniitialize generator for target: %s.\n - Source path: %s' % 
                 (generator.getTarget(), sourceCodeSearchPath.asString()))
 
     # Set up additional options for generation
-    context = glslRenderer.getCodeGenerator().getContext()
+    context = renderer.getCodeGenerator().getContext()
     genOptions = context.getOptions()
     genOptions.emitColorTransforms = True # This is True by default
     genOptions.fileTextureVerticalFlip = True
@@ -569,26 +613,26 @@ def initializeRenderer(stdlib, searchPath,
     #genOptions.addUpstreamDependencies = True
     # 
 
-    return glslRenderer        
+    return renderer        
 
-def performRender(glslRenderer, doc, inputFilename, outputPath, searchPath) -> ( bool, str ):
+def performRender(renderer, doc, inputFilename, outputPath, searchPath) -> ( bool, str ):
 
     rendered = False
     renderErrors = ''
 
-    generator = glslRenderer.getCodeGenerator()
+    generator = renderer.getCodeGenerator()
     context = generator.getContext()
     genOptions = context.getOptions()
     target = context.getShaderGenerator().getTarget()
 
     # Append to search path for image handler
-    imageHandler = glslRenderer.getImageHandler()
+    imageHandler = renderer.getImageHandler()
     imageSearchPathPrev = imageHandler.getSearchPath()
     imageSearchPath = imageSearchPathPrev
     #imageSearchPath.append(searchPath)
     #imageHandler.setSearchPath(imageSearchPath)
     imageHandler.setSearchPath(searchPath)
-    glslRenderer.addToRenderLog(' - Using image search path: %s' % imageHandler.getSearchPath().asString())
+    renderer.addToRenderLog(' - Using image search path: %s' % imageHandler.getSearchPath().asString())
 
     # Append to source code search path
     # TODO: There is no way to get and search the path in the API (C++ or Python)
@@ -596,7 +640,7 @@ def performRender(glslRenderer, doc, inputFilename, outputPath, searchPath) -> (
     generator.registerSourceCodeSearchPath(searchPath)
 
     # Find a renderable and generate the shader for it
-    nodes = glslRenderer.findRenderableElements(doc)
+    nodes = renderer.findRenderableElements(doc)
     if not nodes:
         return
     printSource = False
@@ -610,13 +654,13 @@ def performRender(glslRenderer, doc, inputFilename, outputPath, searchPath) -> (
         if renderNode.getType() == 'material':
             renderNodes = mx.getShaderNodes(renderNode)
             if not renderNodes:
-                glslRenderer.setActiveShaderErrors('- Warning: No surface shader found in material: "%s"' % renderNode.getNamePath())                    
+                renderer.setActiveShaderErrors('- Warning: No surface shader found in material: "%s"' % renderNode.getNamePath())                    
                 renderNode = None
         if renderNode:
-            glslRenderer.addToRenderLog('------- Render Node: %s --------' % renderNode.getNamePath())
-            shader = glslRenderer.generateShader(renderNode, targetColorSpaceOverride, targetDistanceUnit)
+            renderer.addToRenderLog('------- Render Node: %s --------' % renderNode.getNamePath())
+            shader = renderer.generateShader(renderNode, targetColorSpaceOverride, targetDistanceUnit)
         if shader:
-            glslRenderer.addToRenderLog('- Generate shader for node: "%s"\n\t- Is Transparent: %s. V-Flip textures: %d.\n\t- Emit Color Xforms: %d. Default input colorspace: "%s".\n\t- Scene Units: "%s"' %
+            renderer.addToRenderLog('- Generate shader for node: "%s"\n\t- Is Transparent: %s. V-Flip textures: %d.\n\t- Emit Color Xforms: %d. Default input colorspace: "%s".\n\t- Scene Units: "%s"' %
                     (nodes[0].getNamePath(),
                     genOptions.hwTransparency, 
                     genOptions.fileTextureVerticalFlip, 
@@ -624,16 +668,16 @@ def performRender(glslRenderer, doc, inputFilename, outputPath, searchPath) -> (
                     genOptions.targetColorSpaceOverride, 
                     genOptions.targetDistanceUnit))
         else:
-            glslRenderer.addToRenderLog(
+            renderer.addToRenderLog(
                 '- Failed to generate shader for node: "%s". Errors: %s' % (nodes[0].getNamePath(), 
-                                                                            glslRenderer.getActiveShaderErrors()))
+                                                                            renderer.getActiveShaderErrors()))
             continue
 
         if printSource:
-            sourceCode = glslRenderer.getSourceCode()
+            sourceCode = renderer.getSourceCode()
             for stage in sourceCode:
-                glslRenderer.addToRenderLog('-' * 80)
-                glslRenderer.addToRenderLog('- "%s" Stage Code:' % stage)
+                renderer.addToRenderLog('-' * 80)
+                renderer.addToRenderLog('- "%s" Stage Code:' % stage)
                 lines = sourceCode[stage].split('\n')
                 for l in lines:
                     if l.startswith('uniform'):
@@ -641,39 +685,39 @@ def performRender(glslRenderer, doc, inputFilename, outputPath, searchPath) -> (
 
         createdProgram = False
         if shader:
-            createdProgram = glslRenderer.createProgram()
+            createdProgram = renderer.createProgram()
 
         printAttribs = False
         if createdProgram:
-            glslRenderer.addToRenderLog('- Create renderer program from shader')
+            renderer.addToRenderLog('- Create renderer program from shader')
 
-            program = glslRenderer.getProgram()
+            program = renderer.getProgram()
             if program:
                 if printAttribs:
                     attribs = program.getAttributesList()
-                    glslRenderer.addToRenderLog('%d geometry attribs in program' % len(attribs))   
+                    renderer.addToRenderLog('%d geometry attribs in program' % len(attribs))   
                     for attrib in attribs:
-                        glslRenderer.addToRenderLog('- attribute: %s' % attrib)
+                        renderer.addToRenderLog('- attribute: %s' % attrib)
                         input = attribs[attrib] 
                     
                     uniforms = program.getUniformsList()
-                    glslRenderer.addToRenderLog('%d uniforms' % len(uniforms))
+                    renderer.addToRenderLog('%d uniforms' % len(uniforms))
                     for uniform in uniforms:
-                        glslRenderer.addToRenderLog('- Uniform:', uniform)
+                        renderer.addToRenderLog('- Uniform:', uniform)
                         port = uniforms[uniform]
-                        glslRenderer.addToRenderLog('  - Port type:', port.gltype)   
+                        renderer.addToRenderLog('  - Port type:', port.gltype)   
 
         runRender = True
         if createdProgram and runRender:
-            rendered, renderErrors = glslRenderer.render()
+            rendered, renderErrors = renderer.render()
             if not rendered:
-                glslRenderer.addToRenderLog('- Failed to render, Errors: %s' % renderErrors)
+                renderer.addToRenderLog('- Failed to render, Errors: %s' % renderErrors)
             #else:
-            #    glslRenderer.addToRenderLog('- Successfully rendered frame.')
+            #    renderer.addToRenderLog('- Successfully rendered frame.')
 
         if rendered:
-            glslRenderer.captureImage()
-            capturedImage = glslRenderer.getCapturedImage()
+            renderer.captureImage()
+            capturedImage = renderer.getCapturedImage()
             if capturedImage:
                 flipImage = True        
                 outputString = mx.FilePath(mx.createValidName(renderNode.getNamePath()) + '_' + target)
@@ -682,8 +726,8 @@ def performRender(glslRenderer, doc, inputFilename, outputPath, searchPath) -> (
                     fileName = outputPath / outputString
                 else:
                     fileName = mx.FilePath(inputFilename).getParentPath() / outputString
-                glslRenderer.addToRenderLog('- Saved rendered image to: %s' % fileName.asString())                             
-                glslRenderer.saveCapture(fileName, flipImage)
+                renderer.addToRenderLog('- Saved rendered image to: %s' % fileName.asString())                             
+                renderer.saveCapture(fileName, flipImage)
     
     # Restore image search path
     imageHandler.setSearchPath(imageSearchPathPrev)

--- a/pymaterialx/mtlxutils/mxrenderer.py
+++ b/pymaterialx/mtlxutils/mxrenderer.py
@@ -615,7 +615,7 @@ def initializeRenderer(stdlib, searchPath,
 
     return renderer        
 
-def performRender(renderer, doc, inputFilename, outputPath, searchPath) -> ( bool, str ):
+def performRender(renderer, doc, inputFilename, outputPath, searchPath) -> tuple[ bool, str ]:
 
     rendered = False
     renderErrors = ''
@@ -628,9 +628,6 @@ def performRender(renderer, doc, inputFilename, outputPath, searchPath) -> ( boo
     # Append to search path for image handler
     imageHandler = renderer.getImageHandler()
     imageSearchPathPrev = imageHandler.getSearchPath()
-    imageSearchPath = imageSearchPathPrev
-    #imageSearchPath.append(searchPath)
-    #imageHandler.setSearchPath(imageSearchPath)
     imageHandler.setSearchPath(searchPath)
     renderer.addToRenderLog(' - Using image search path: %s' % imageHandler.getSearchPath().asString())
 
@@ -642,7 +639,7 @@ def performRender(renderer, doc, inputFilename, outputPath, searchPath) -> ( boo
     # Find a renderable and generate the shader for it
     nodes = renderer.findRenderableElements(doc)
     if not nodes:
-        return
+        return False, 'No renderable nodes found in document.'
     printSource = False
 
     # Set up overrides for color space and units. Color space may come from the document,

--- a/pymaterialx/renderDocuments.py
+++ b/pymaterialx/renderDocuments.py
@@ -49,11 +49,12 @@ def getFiles(rootPath):
 
 def main():
     parser = argparse.ArgumentParser(description="Extract out source implementation information.")
-    parser.add_argument('--outputPath', dest='outputPath', default="", help="Output path. Default is empty.")
-    parser.add_argument('--path', dest='paths', action='append', nargs='+', help='An additional absolute search path location (e.g. "/projects/MaterialX")')
-    parser.add_argument('--library', dest='libraries', action='append', nargs='+', help='An additional relative path to a custom data library folder (e.g. "libraries/custom")')
-    parser.add_argument('--geometryPath', dest='geometryPath', default="", help="Path to geometry shape. Default is empty")
-    parser.add_argument('--size', dest='size', default=-1, type=int, help="Size of the render. Default is 512.")
+    parser.add_argument('-op', '--outputPath', dest='outputPath', default="", help="Output path. Default is empty.")
+    parser.add_argument('-p', '--path', dest='paths', action='append', nargs='+', help='An additional absolute search path location (e.g. "/projects/MaterialX")')
+    parser.add_argument('-l', '--library', dest='libraries', action='append', nargs='+', help='An additional relative path to a custom data library folder (e.g. "libraries/custom")')
+    parser.add_argument('-g', '--geometryPath', dest='geometryPath', default="", help="Path to geometry shape. Default is empty")
+    parser.add_argument('-s', '--size', dest='size', default=-1, type=int, help="Size of the render. Default is 512.")
+    parser.add_argument('-t', '--target', dest='target', default='genglsl', help='Target shader generator to use (e.g. "genglsl, genosl, genmdl, genmsl"). Default is glsl.')
     parser.add_argument(dest="inputFileName", help="Filename of the input document.")
     opts = parser.parse_args()
 
@@ -128,7 +129,7 @@ def main():
             logger.error('-- Geometry shape "%s" does not exist. Exiting', geometryShape)
             exit(-1)
         renderer = mxrenderer.initializeRenderer(stdlib, searchPath, radianceFilePath, irradianceFilePath, w, h, 
-                                                 geometryShape)
+                                                 geometryShape, opts.target)
         renderer.addToRenderLog('--------------------------')
 
     if not renderer:


### PR DESCRIPTION
## Change

Sample Metal renderer support trivially added by deriving from base GLSL renderer class and adding virtual overrides for renderer, image handler usage.

Added `-t / --target` arg to `renderDocuments.py` to allow for `genmsl` (Metal) to be specified vs default of `genglsl` (GLSL).

## Requirements

- Requires this core PR change to allow image handlers to be specified: https://github.com/AcademySoftwareFoundation/MaterialX/pull/2855 

## Examples

| | |
|:--:|:--:|
| <img width="512" height="512" alt="Boombox_genmsl" src="https://github.com/user-attachments/assets/f3096108-418f-4856-ba2f-8ff4ed6653ad" /> | <img width="512" height="512" alt="surfacematerial_material_genmsl" src="https://github.com/user-attachments/assets/a656645a-cf47-4fba-aa78-5a08853dd0cb" /> |
| <img width="512" height="512" alt="M_BrickPattern_genmsl" src="https://github.com/user-attachments/assets/9d5ef05b-c7db-426f-a40c-1598811dd1b4" /> | <img width="512" height="512" alt="M_Queen_B_genmsl" src="https://github.com/user-attachments/assets/09cce0ed-246d-4c77-9637-f52139be368e" /> |


